### PR TITLE
Add namespace awareness

### DIFF
--- a/com.doc.xpi.af.modules.sequencer.ejb/ejbModule/com/doc/xpi/af/modules/sequencer/SetSequenceIdBean.java
+++ b/com.doc.xpi.af.modules.sequencer.ejb/ejbModule/com/doc/xpi/af/modules/sequencer/SetSequenceIdBean.java
@@ -162,10 +162,34 @@ public class SetSequenceIdBean implements Module {
 
 		try {
 			DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
+			documentFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(inputStream);
 			XPathFactory xPathFactory = XPathFactory.newInstance();
 			XPath xPath = xPathFactory.newXPath();
+			xPath.setNamespaceContext( new NamespaceContext() {
+			    public String getNamespaceURI(String prefix) {
+			      if(prefix.equals("ns0")) {
+			    	  return "http://schemas.example.com/shemas/common";
+			       }
+			      return null;
+			    }
+
+				@Override
+				public String getPrefix(String namespaceURI) {
+					// Not sneeded in this context
+					if(namespaceURI.equals("http://schemas.example.com/shemas/common") {
+				    	  return "ns0";
+				    }
+					return null;
+				}
+
+		     	@Override
+				public Iterator getPrefixes(String arg0) {
+					// Not neededed in this context
+					return null;
+				}
+			});
 			XPathExpression xPathExpression = xPath.compile(xPathExpressionValue);
 			value = (String) xPathExpression.evaluate(document,
 					XPathConstants.STRING);


### PR DESCRIPTION
Thanks for this adapter module, great work and really helped us out a lot. We did run into a problem with a namespace in the payload causing the xpath evaluation to fail. A similar problem is described here: https://stackoverflow.com/questions/36905688/xpath-expression-unable-to-match. This PR contains a fix for that. I have not tested it on non-namespaced payloads yet. Please check if you are willing to merge otherwise just ignore